### PR TITLE
Cray Compiler Requires Headers for uint64_t

### DIFF
--- a/src/ParticleVaultContainer.cc
+++ b/src/ParticleVaultContainer.cc
@@ -1,3 +1,6 @@
+
+#include <cstdint>
+
 #include "ParticleVaultContainer.hh"
 #include "ParticleVault.hh"
 #include "SendQueue.hh"

--- a/src/ParticleVaultContainer.cc
+++ b/src/ParticleVaultContainer.cc
@@ -1,6 +1,3 @@
-
-#include <cstdint>
-
 #include "ParticleVaultContainer.hh"
 #include "ParticleVault.hh"
 #include "SendQueue.hh"

--- a/src/ParticleVaultContainer.hh
+++ b/src/ParticleVaultContainer.hh
@@ -2,8 +2,11 @@
 #define PARTICLEVAULTCONTAINER_HH
 
 #include "DeclareMacro.hh"
+
+#include "portability.hh"
 #include "QS_Vector.hh"
 #include <vector>
+
 //---------------------------------------------------------------
 // ParticleVaultContainer is a container of ParticleVaults. 
 // These Vaults are broken down into user defined chunks that can 


### PR DESCRIPTION
Cray Compiler requires either `cstdint` or `cinttypes` in order to successfully compile. 