### PR TITLE
Bringing in missing changes from previous versions:

### DIFF
--- a/src/MC_Domain.cc
+++ b/src/MC_Domain.cc
@@ -379,7 +379,10 @@ MC_Domain::MC_Domain(const MeshPartition& meshPartition, const GlobalFccGrid& gr
       cell_state[ii]._total = _cachedCrossSectionStorage.getBlock(numEnergyGroups);
 
       int numIsos = static_cast<int>(materialDatabase._mat[cell_state[ii]._material]._iso.size());
-      cell_state[ii]._cellNumberDensity = 1.0 / numIsos;
+      //  The cellNumberDensity scales the crossSections so we choose to
+      //  set this density to 1.0 so that the totalCrossSection will be
+      //  as requested by the user.
+      cell_state[ii]._cellNumberDensity = 1.0;
 
       MC_Vector cellCenter = findCellCenter(mesh._cellConnectivity[ii], mesh._node);
       cell_state[ii]._id = grid.whichCell(cellCenter) * UINT64_C(0x0100000000);

--- a/src/MacroscopicCrossSection.cc
+++ b/src/MacroscopicCrossSection.cc
@@ -19,10 +19,12 @@ double macroscopicCrossSection(MonteCarlo* monteCarlo, int reactionIndex, int do
    int globalMatIndex = monteCarlo->domain[domainIndex].cell_state[cellIndex]._material;
 
    double atomFraction = monteCarlo->_materialDatabase->_mat[globalMatIndex]._iso[isoIndex]._atomFraction;
-   atomFraction = 1.0;
 
    double microscopicCrossSection = 0.0;
-   // The number density is atoms per cell volume.
+   // The cell number density is the fraction of the atoms in cell
+   // volume of this isotope.  We set this (elsewhere) to 1/nIsotopes.
+   // This is a statement that we treat materials as if all of their
+   // isotopes are present in equal amounts
    double cellNumberDensity = monteCarlo->domain[domainIndex].cell_state[cellIndex]._cellNumberDensity;
 
    int isotopeGid = monteCarlo->_materialDatabase->_mat[globalMatIndex]._iso[isoIndex]._gid;


### PR DESCRIPTION
1) Work on improving the cross sections. This converts the interpretation of the polynomials representing cross sections so that they are in log-log space. We also change the normalization of the cross sections so that you specify the total cross section and cross section ratios at 1MeV instead of averages. The former is much easier to obtain from cross section plots. These changes do not alter the behavior of the default problem since it uses flat cross sections. Flat cross sections are not changed by these modifications.

2) Make more sensible use of the atomFraction and cellNumberDensity quantities when computing macroscopic cross sections. Now both need to be retrieved (atomFraction was set locally). Also, atomFraction is (sensibly) 1/nIsotopes and cellNumberDensity is (somewhat arbitrarily) 1.0