### PR TITLE
Energy Spectrum Printing

### DIFF
--- a/src/EnergySpectrum.cc
+++ b/src/EnergySpectrum.cc
@@ -1,0 +1,61 @@
+#include "EnergySpectrum.hh"
+#include "MonteCarlo.hh"
+#include "ParticleVault.hh"
+#include "ParticleVaultContainer.hh"
+#include "NuclearData.hh"
+#include "utilsMpi.hh"
+#include "MC_Processor_Info.hh"
+#include "Parameters.hh"
+#include <string>
+
+using std::string;
+
+void updateSpectrum( MonteCarlo* monteCarlo, uint64_t *hist )
+{
+    if( monteCarlo->_params.simulationParams.energySpectrum == "" ) return;
+
+    for( uint64_t ii = 0; ii < monteCarlo->_particleVaultContainer->processingSize(); ii++)
+    {
+        ParticleVault* processing = monteCarlo->_particleVaultContainer->getTaskProcessingVault( ii );
+        for( uint64_t jj = 0; jj < processing->size(); jj++ )
+        {
+            MC_Particle mc_particle;
+            MC_Load_Particle(monteCarlo, mc_particle, processing, jj);
+            hist[mc_particle.energy_group]++;
+        }
+    }
+    for( uint64_t ii = 0; ii < monteCarlo->_particleVaultContainer->processedSize(); ii++)
+    {
+        ParticleVault* processed = monteCarlo->_particleVaultContainer->getTaskProcessedVault( ii );
+        for( uint64_t jj = 0; jj < processed->size(); jj++ )
+        {
+            MC_Particle mc_particle;
+            MC_Load_Particle(monteCarlo, mc_particle, processed, jj);
+            hist[mc_particle.energy_group]++;
+        }
+    }
+}
+
+void printSpectrum( uint64_t *hist, MonteCarlo* monteCarlo)
+{
+    if( monteCarlo->_params.simulationParams.energySpectrum == "" ) return;
+
+    const int count = monteCarlo->_nuclearData->_energies.size();
+    uint64_t *sumHist = new uint64_t[ count ]();
+
+    mpiAllreduce( hist, sumHist, count, MPI_INT64_T, MPI_SUM, monteCarlo->processor_info->comm_mc_world );
+
+    if( monteCarlo->processor_info->rank == 0 )
+    {
+        string fileName = monteCarlo->_params.simulationParams.energySpectrum + ".dat";
+        FILE* spectrumFile;
+        spectrumFile = fopen( fileName.c_str(), "w" );
+
+        for( int ii = 0; ii < 230; ii++ )
+        {
+            fprintf( spectrumFile, "%d\t%g\t%lu\n", ii, monteCarlo->_nuclearData->_energies[ii], sumHist[ii] );
+        }
+
+        fclose( spectrumFile );
+    }
+}

--- a/src/EnergySpectrum.hh
+++ b/src/EnergySpectrum.hh
@@ -1,0 +1,10 @@
+#ifndef ENERGYSPECTRUM_HH
+#define ENERGYSPECTRUM_HH
+#include <string>
+
+class MonteCarlo;
+
+void updateSpectrum( MonteCarlo* monteCarlo, uint64_t *hist );
+void printSpectrum( uint64_t *hist, MonteCarlo* monteCarlo);
+#endif
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -274,6 +274,7 @@ SOURCES= \
     CycleTracking.cc \
     DecompositionObject.cc \
     DirectionCosine.cc \
+    EnergySpectrum.cc \
     GlobalFccGrid.cc \
     GridAssignmentObject.cc \
     InputBlock.cc \

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -81,9 +81,21 @@ Parameters getParameters(int argc, char** argv)
 {
    Parameters params;
    parseCommandLine(argc, argv, params);
-   const string& filename = params.simulationParams.inputFile;
+<<<<<<< HEAD
+   const string& filename  = params.simulationParams.inputFile;
+   const string energyName = params.simulationParams.energySpectrum;
    if (!filename.empty())
       parseInputFile(filename, params);
+   if( energyName != "" )
+       params.simulationParams.energySpectrum = energyName;
+=======
+   const string& filename = params.simulationParams.inputFile;
+   const string xsecOut   = params.simulationParams.crossSectionsOut;
+   if (!filename.empty())
+      parseInputFile(filename, params);
+   if( xsecOut != "" )
+      params.simulationParams.crossSectionsOut = xsecOut;
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
 
    supplyDefaults(params);
 
@@ -117,6 +129,7 @@ ostream& operator<<(ostream& out, const SimulationParameters& pp)
    out << "   dt: " << pp.dt << "\n";
    out << "   fMax: " << pp.fMax << "\n";
    out << "   inputFile: " << pp.inputFile << "\n";
+   out << "   energySpectrum: " << pp.energySpectrum << "\n";
    out << "   boundaryCondition: " << pp.boundaryCondition << "\n";
    out << "   loadBalance: " << pp.loadBalance << "\n";
    out << "   cycleTimers: " << pp.cycleTimers << "\n";
@@ -143,6 +156,7 @@ ostream& operator<<(ostream& out, const SimulationParameters& pp)
    out << "   fTally: " << pp.fluxTallyReplications << "\n";
    out << "   cTally: " << pp.cellTallyReplications << "\n";
    out << "   coralBenchmark: " << pp.coralBenchmark << "\n";
+   out << "   crossSectionsOut:" << pp.crossSectionsOut << "\n";
    out << endl;
    return out;
 }
@@ -216,11 +230,23 @@ namespace
       int help=0;
       char name[1024];
       name[0] = '\0';
+<<<<<<< HEAD
+      char esName[1024];
+      esName[0] = '\0';
+=======
+      char xsec[1024];
+      xsec[0] = '\0';
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
       
       addArg("help",             'h', 0, 'i', &(help),           0,      "print this message");
       addArg("dt",               'D', 1, 'd', &(sp.dt),          0,      "time step (seconds)");
       addArg("fMax",             'f', 1, 'd', &(sp.fMax),        0,      "max random mesh node displacement");
       addArg("inputFile",        'i', 1, 's', &(name),     sizeof(name), "name of input file");
+<<<<<<< HEAD
+      addArg("energySpectrum",   'e', 1, 's', &(esName),     sizeof(esName), "name of energy spectrum output file");
+=======
+      addArg("crossSectionsOut", 'S', 1, 's', &(xsec),     sizeof(xsec), "name of cross section output file");
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
       addArg("loadBalance",      'l', 0, 'i', &(sp.loadBalance), 0,      "enable/disable load balancing" );
       addArg("cycleTimers",      'c', 1, 'i', &(sp.cycleTimers), 0,      "enable/disable cycle timers" );
       addArg("debugThreads",     't', 1, 'i', &(sp.debugThreads),0,      "set thread debug level to 1, 2, 3" );
@@ -245,6 +271,11 @@ namespace
       processArgs(argc, argv);
 
       sp.inputFile = name;
+<<<<<<< HEAD
+      sp.energySpectrum = esName;
+=======
+      sp.crossSectionsOut = xsec;
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
 
       if (help)
       {
@@ -370,6 +401,11 @@ namespace
    void scanSimulationBlock(const InputBlock& input, Parameters& pp)
    {
       SimulationParameters& sp = pp.simulationParams;
+<<<<<<< HEAD
+      input.getValue<string>("energySpectrum", sp.energySpectrum);
+=======
+      input.getValue<string>("crossSectionsOut",sp.crossSectionsOut);
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
       input.getValue<string>("boundaryCondition", sp.boundaryCondition);
       input.getValue<double>("dt",          sp.dt);
       input.getValue<double>("fMax",        sp.fMax);

--- a/src/Parameters.hh
+++ b/src/Parameters.hh
@@ -98,7 +98,9 @@ struct SimulationParameters
 {
    SimulationParameters()
    : inputFile(),
+     crossSectionsOut(""),
      boundaryCondition("reflect"),
+     energySpectrum(""),
      loadBalance(0),
      cycleTimers(0),
      debugThreads(0),
@@ -132,6 +134,11 @@ struct SimulationParameters
    {};
 
    std::string inputFile;        //!< name of input file
+<<<<<<< HEAD
+   std::string energySpectrum;   //!< enble computing and printing energy spectrum via of energy spectrum file 
+=======
+   std::string crossSectionsOut; //!< enable or disable printing cross section data to a file
+>>>>>>> 6dbb362... 1) Added printing cross sections as an input parameter. (#17)
    std::string boundaryCondition;//!< specifies boundary conditions
    int loadBalance;              //!< enable or disable load balancing
    int cycleTimers;              //!< enable or disable cycle timers 


### PR DESCRIPTION
1) Added functions to compute the energy spectrum of particles that reach census
2) Added function to print histogram of energy spectrum to a file
3) Made computing/printing energy spectrum an input deck argument
   Turn on plotting energy spectrum by providing a file name in the input deck
   or command line