### PR TITLE
Energy Spectrum Printing

### DIFF
--- a/src/EnergySpectrum.cc
+++ b/src/EnergySpectrum.cc
@@ -1,0 +1,70 @@
+#include "EnergySpectrum.hh"
+#include "MonteCarlo.hh"
+#include "ParticleVault.hh"
+#include "ParticleVaultContainer.hh"
+#include "NuclearData.hh"
+#include "utilsMpi.hh"
+#include "MC_Processor_Info.hh"
+#include "Parameters.hh"
+#include <string>
+
+using std::string;
+
+void EnergySpectrum::Allocate(string name, uint64_t size)
+{
+    fileName = name;
+
+    if( fileName == "" ) return;
+
+    CensusEnergySpectrum = new uint64_t [size];
+}
+
+void EnergySpectrum::UpdateSpectrum(MonteCarlo* monteCarlo)
+{
+    if( fileName == "" ) return;
+
+    for( uint64_t ii = 0; ii < monteCarlo->_particleVaultContainer->processingSize(); ii++)
+    {
+        ParticleVault* processing = monteCarlo->_particleVaultContainer->getTaskProcessingVault( ii );
+        for( uint64_t jj = 0; jj < processing->size(); jj++ )
+        {
+            MC_Particle mc_particle;
+            MC_Load_Particle(monteCarlo, mc_particle, processing, jj);
+            CensusEnergySpectrum[mc_particle.energy_group]++;
+        }
+    }
+    for( uint64_t ii = 0; ii < monteCarlo->_particleVaultContainer->processedSize(); ii++)
+    {
+        ParticleVault* processed = monteCarlo->_particleVaultContainer->getTaskProcessedVault( ii );
+        for( uint64_t jj = 0; jj < processed->size(); jj++ )
+        {
+            MC_Particle mc_particle;
+            MC_Load_Particle(monteCarlo, mc_particle, processed, jj);
+            CensusEnergySpectrum[mc_particle.energy_group]++;
+        }
+    }
+}
+
+void EnergySpectrum::PrintSpectrum(MonteCarlo* monteCarlo)
+{
+    if( fileName == "" ) return;
+
+    const int count = monteCarlo->_nuclearData->_energies.size();
+    uint64_t *sumHist = new uint64_t[ count ]();
+
+    mpiAllreduce( CensusEnergySpectrum, sumHist, count, MPI_INT64_T, MPI_SUM, monteCarlo->processor_info->comm_mc_world );
+
+    if( monteCarlo->processor_info->rank == 0 )
+    {
+        fileName += ".dat";
+        FILE* spectrumFile;
+        spectrumFile = fopen( fileName.c_str(), "w" );
+
+        for( int ii = 0; ii < 230; ii++ )
+        {
+            fprintf( spectrumFile, "%d\t%g\t%lu\n", ii, monteCarlo->_nuclearData->_energies[ii], sumHist[ii] );
+        }
+
+        fclose( spectrumFile );
+    }
+}

--- a/src/EnergySpectrum.hh
+++ b/src/EnergySpectrum.hh
@@ -1,20 +1,23 @@
 #ifndef ENERGYSPECTRUM_HH
 #define ENERGYSPECTRUM_HH
 #include <string>
+#include <vector>
 
 class MonteCarlo;
 
 class EnergySpectrum
 {
     public:
-        EnergySpectrum() : fileName("") {}
-        void Allocate(std::string name, uint64_t size);
+        EnergySpectrum() : _fileName(""), _censusEnergySpectrum(0) {};
+        EnergySpectrum(std::string name, uint64_t size) : _fileName(name), _censusEnergySpectrum(size,0) {};
+        void SetFileName( std::string name){ _fileName = name; }
+        void ResizeSpectrum( int size ){ _censusEnergySpectrum.resize(size, 0);}
         void UpdateSpectrum(MonteCarlo* monteCarlo);
         void PrintSpectrum(MonteCarlo* monteCarlo);
 
     private:
-        std::string fileName;
-        uint64_t *CensusEnergySpectrum;
+        std::string _fileName;
+        std::vector<uint64_t> _censusEnergySpectrum;
 };
 
 #endif

--- a/src/EnergySpectrum.hh
+++ b/src/EnergySpectrum.hh
@@ -1,0 +1,21 @@
+#ifndef ENERGYSPECTRUM_HH
+#define ENERGYSPECTRUM_HH
+#include <string>
+
+class MonteCarlo;
+
+class EnergySpectrum
+{
+    public:
+        EnergySpectrum() : fileName("") {}
+        void Allocate(std::string name, uint64_t size);
+        void UpdateSpectrum(MonteCarlo* monteCarlo);
+        void PrintSpectrum(MonteCarlo* monteCarlo);
+
+    private:
+        std::string fileName;
+        uint64_t *CensusEnergySpectrum;
+};
+
+#endif
+

--- a/src/EnergySpectrum.hh
+++ b/src/EnergySpectrum.hh
@@ -8,10 +8,7 @@ class MonteCarlo;
 class EnergySpectrum
 {
     public:
-        EnergySpectrum() : _fileName(""), _censusEnergySpectrum(0) {};
         EnergySpectrum(std::string name, uint64_t size) : _fileName(name), _censusEnergySpectrum(size,0) {};
-        void SetFileName( std::string name){ _fileName = name; }
-        void ResizeSpectrum( int size ){ _censusEnergySpectrum.resize(size, 0);}
         void UpdateSpectrum(MonteCarlo* monteCarlo);
         void PrintSpectrum(MonteCarlo* monteCarlo);
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -274,6 +274,7 @@ SOURCES= \
     CycleTracking.cc \
     DecompositionObject.cc \
     DirectionCosine.cc \
+	EnergySpectrum.cc \
     GlobalFccGrid.cc \
     GridAssignmentObject.cc \
     InputBlock.cc \

--- a/src/MonteCarlo.cc
+++ b/src/MonteCarlo.cc
@@ -35,14 +35,18 @@ MonteCarlo::MonteCarlo(const Parameters& params)
 
         _tallies                = new(ptr1) Tallies( params.simulationParams.balanceTallyReplications, 
                                                      params.simulationParams.fluxTallyReplications,
-                                                     params.simulationParams.cellTallyReplications);
+                                                     params.simulationParams.cellTallyReplications, 
+                                                     params.simulationParams.energySpectrum,
+                                                     params.simulationParams.nGroups);
         processor_info          = new(ptr2) MC_Processor_Info();
         time_info               = new(ptr3) MC_Time_Info();
         fast_timer              = new(ptr4) MC_Fast_Timer_Container();
     #else
         _tallies                = new Tallies( params.simulationParams.balanceTallyReplications, 
                                                params.simulationParams.fluxTallyReplications,
-                                               params.simulationParams.cellTallyReplications);
+                                               params.simulationParams.cellTallyReplications,
+                                               params.simulationParams.energySpectrum,
+                                               params.simulationParams.nGroups);
         processor_info          = new MC_Processor_Info();
         time_info               = new MC_Time_Info();
         fast_timer              = new MC_Fast_Timer_Container();

--- a/src/NuclearData.cc
+++ b/src/NuclearData.cc
@@ -3,6 +3,7 @@
 #include "MC_RNG_State.hh"
 #include "DeclareMacro.hh"
 #include "qs_assert.hh"
+#include "EnergySpectrum.hh"
 
 using std::log10;
 using std::pow;
@@ -102,7 +103,7 @@ void NuclearDataSpecies::addReaction(
 
 
 // Set up the energies boundaries of the neutron
-NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh) : _energies( numGroups+1,VAR_MEM)
+NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh, std::string spectrumName) : _energies( numGroups+1,VAR_MEM)
 {
    qs_assert (energyLow < energyHigh);
    _numEnergyGroups = numGroups;
@@ -116,6 +117,15 @@ NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh) : _
       double logValue = logLow + delta *energyIndex;
       _energies[energyIndex] = exp(logValue);
    }
+   _spectrum = new EnergySpectrum;
+   _spectrum->Allocate( spectrumName, _numEnergyGroups );
+}
+
+NuclearData::~NuclearData()
+{
+    delete _spectrum;
+   _isotopes.~qs_vector();
+   _energies.~qs_vector();
 }
 
 

--- a/src/NuclearData.cc
+++ b/src/NuclearData.cc
@@ -103,7 +103,7 @@ void NuclearDataSpecies::addReaction(
 
 
 // Set up the energies boundaries of the neutron
-NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh, std::string spectrumName) : _energies( numGroups+1,VAR_MEM)
+NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh) : _energies( numGroups+1,VAR_MEM)
 {
    qs_assert (energyLow < energyHigh);
    _numEnergyGroups = numGroups;
@@ -117,17 +117,7 @@ NuclearData::NuclearData(int numGroups, double energyLow, double energyHigh, std
       double logValue = logLow + delta *energyIndex;
       _energies[energyIndex] = exp(logValue);
    }
-   _spectrum = new EnergySpectrum;
-   _spectrum->Allocate( spectrumName, _numEnergyGroups );
 }
-
-NuclearData::~NuclearData()
-{
-    delete _spectrum;
-   _isotopes.~qs_vector();
-   _energies.~qs_vector();
-}
-
 
 int NuclearData::addIsotope(
    int nReactions,

--- a/src/NuclearData.hh
+++ b/src/NuclearData.hh
@@ -10,8 +10,6 @@
 #include "qs_assert.hh"
 #include "DeclareMacro.hh"
 
-class EnergySpectrum;
-
 class Polynomial
 {
  public:
@@ -88,8 +86,7 @@ class NuclearData
 {
  public:
    
-   NuclearData(int numGroups, double energyLow, double energyHigh, std::string spectrumName);
-   ~NuclearData();
+   NuclearData(int numGroups, double energyLow, double energyHigh);
 
    int addIsotope(int nReactions,
                   const Polynomial& fissionFunction,
@@ -116,7 +113,6 @@ class NuclearData
    // neutrons, this array would be a vector of vectors.
    qs_vector<double> _energies;
 
-   EnergySpectrum *_spectrum;
 };
 
 #endif

--- a/src/NuclearData.hh
+++ b/src/NuclearData.hh
@@ -10,6 +10,8 @@
 #include "qs_assert.hh"
 #include "DeclareMacro.hh"
 
+class EnergySpectrum;
+
 class Polynomial
 {
  public:
@@ -86,7 +88,8 @@ class NuclearData
 {
  public:
    
-   NuclearData(int numGroups, double energyLow, double energyHigh);
+   NuclearData(int numGroups, double energyLow, double energyHigh, std::string spectrumName);
+   ~NuclearData();
 
    int addIsotope(int nReactions,
                   const Polynomial& fissionFunction,
@@ -112,6 +115,8 @@ class NuclearData
    // This is the overall energy layout. If we had more than just
    // neutrons, this array would be a vector of vectors.
    qs_vector<double> _energies;
+
+   EnergySpectrum *_spectrum;
 };
 
 #endif

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -82,11 +82,12 @@ Parameters getParameters(int argc, char** argv)
    Parameters params;
    parseCommandLine(argc, argv, params);
    const string& filename = params.simulationParams.inputFile;
+   const string energyName = params.simulationParams.energySpectrum;
    const string xsecOut   = params.simulationParams.crossSectionsOut;
-   if (!filename.empty())
-      parseInputFile(filename, params);
-   if( xsecOut != "" )
-      params.simulationParams.crossSectionsOut = xsecOut;
+
+   if (!filename.empty()) parseInputFile(filename, params);
+   if( energyName != "" ) params.simulationParams.energySpectrum = energyName;
+   if( xsecOut != "" )    params.simulationParams.crossSectionsOut = xsecOut;
 
    supplyDefaults(params);
 
@@ -120,6 +121,7 @@ ostream& operator<<(ostream& out, const SimulationParameters& pp)
    out << "   dt: " << pp.dt << "\n";
    out << "   fMax: " << pp.fMax << "\n";
    out << "   inputFile: " << pp.inputFile << "\n";
+   out << "   energySpectrum: " << pp.energySpectrum << "\n";
    out << "   boundaryCondition: " << pp.boundaryCondition << "\n";
    out << "   loadBalance: " << pp.loadBalance << "\n";
    out << "   cycleTimers: " << pp.cycleTimers << "\n";
@@ -220,6 +222,8 @@ namespace
       int help=0;
       char name[1024];
       name[0] = '\0';
+      char esName[1024];
+      esName[0] = '\0';
       char xsec[1024];
       xsec[0] = '\0';
       
@@ -227,6 +231,7 @@ namespace
       addArg("dt",               'D', 1, 'd', &(sp.dt),          0,      "time step (seconds)");
       addArg("fMax",             'f', 1, 'd', &(sp.fMax),        0,      "max random mesh node displacement");
       addArg("inputFile",        'i', 1, 's', &(name),     sizeof(name), "name of input file");
+      addArg("energySpectrum",   'e', 1, 's', &(esName),     sizeof(esName), "name of energy spectrum output file");
       addArg("crossSectionsOut", 'S', 1, 's', &(xsec),     sizeof(xsec), "name of cross section output file");
       addArg("loadBalance",      'l', 0, 'i', &(sp.loadBalance), 0,      "enable/disable load balancing" );
       addArg("cycleTimers",      'c', 1, 'i', &(sp.cycleTimers), 0,      "enable/disable cycle timers" );
@@ -252,6 +257,7 @@ namespace
       processArgs(argc, argv);
 
       sp.inputFile = name;
+      sp.energySpectrum = esName;
       sp.crossSectionsOut = xsec;
 
       if (help)
@@ -378,6 +384,7 @@ namespace
    void scanSimulationBlock(const InputBlock& input, Parameters& pp)
    {
       SimulationParameters& sp = pp.simulationParams;
+      input.getValue<string>("energySpectrum", sp.energySpectrum);
       input.getValue<string>("crossSectionsOut",sp.crossSectionsOut);
       input.getValue<string>("boundaryCondition", sp.boundaryCondition);
       input.getValue<double>("dt",          sp.dt);

--- a/src/Parameters.hh
+++ b/src/Parameters.hh
@@ -100,6 +100,7 @@ struct SimulationParameters
    : inputFile(),
      crossSectionsOut(""),
      boundaryCondition("reflect"),
+     energySpectrum(""),
      loadBalance(0),
      cycleTimers(0),
      debugThreads(0),
@@ -133,6 +134,7 @@ struct SimulationParameters
    {};
 
    std::string inputFile;        //!< name of input file
+   std::string energySpectrum;   //!< enble computing and printing energy spectrum via of energy spectrum file 
    std::string crossSectionsOut; //!< enable or disable printing cross section data to a file
    std::string boundaryCondition;//!< specifies boundary conditions
    int loadBalance;              //!< enable or disable load balancing

--- a/src/Tallies.cc
+++ b/src/Tallies.cc
@@ -94,6 +94,7 @@ void Tallies::CycleFinalize(MonteCarlo *monteCarlo)
         _cellTallyDomain[domainIndex]._task[0].Reset();
         _scalarFluxDomain[domainIndex]._task[0].Reset();
     }
+    _spectrum.UpdateSpectrum(monteCarlo);
 }
 
 void Fluence::compute( int domainIndex, ScalarFluxDomain &scalarFluxDomain )
@@ -172,9 +173,14 @@ double Tallies::ScalarFluxSum(MonteCarlo *monteCarlo)
 void Tallies::InitializeTallies( MonteCarlo *monteCarlo, 
                         int balance_replications = 1, 
                         int flux_replications = 1, 
-                        int cell_replications = 1 ) 
+                        int cell_replications = 1,
+                        std::string name = "",
+                        int size = 0
+                        ) 
 {
 
+    _spectrum.SetFileName( name );
+    _spectrum.ResizeSpectrum( size );
     //Set num replications from input parameters
     _num_balance_replications   = balance_replications;
     _num_flux_replications      = flux_replications;

--- a/src/Tallies.cc
+++ b/src/Tallies.cc
@@ -173,14 +173,10 @@ double Tallies::ScalarFluxSum(MonteCarlo *monteCarlo)
 void Tallies::InitializeTallies( MonteCarlo *monteCarlo, 
                         int balance_replications = 1, 
                         int flux_replications = 1, 
-                        int cell_replications = 1,
-                        std::string name = "",
-                        int size = 0
+                        int cell_replications = 1
                         ) 
 {
 
-    _spectrum.SetFileName( name );
-    _spectrum.ResizeSpectrum( size );
     //Set num replications from input parameters
     _num_balance_replications   = balance_replications;
     _num_flux_replications      = flux_replications;

--- a/src/Tallies.hh
+++ b/src/Tallies.hh
@@ -4,6 +4,7 @@
 #include "portability.hh"
 #include "QS_Vector.hh"
 #include <stdlib.h>
+#include <string>
 #include <vector>
 #include <cinttypes>
 #include "NuclearData.hh"
@@ -307,14 +308,10 @@ class Tallies
     Fluence                     _fluence;
     EnergySpectrum              _spectrum;
     
-    Tallies() : _balanceCumulative(), _balanceTask(),
-        _scalarFluxDomain(), _num_balance_replications(1), 
-        _num_flux_replications(1), _num_cellTally_replications(1)
-    {}
-
-    Tallies( int balRep, int fluxRep, int cellRep ) : _balanceCumulative(), _balanceTask(),
+    Tallies( int balRep, int fluxRep, int cellRep, std::string spectrumName, int spectrumSize ) : _balanceCumulative(), _balanceTask(),
         _scalarFluxDomain(), _num_balance_replications(balRep), 
-        _num_flux_replications(fluxRep), _num_cellTally_replications(cellRep)
+        _num_flux_replications(fluxRep), _num_cellTally_replications(cellRep), 
+        _spectrum(spectrumName, spectrumSize)
     {
     }
 
@@ -341,9 +338,7 @@ class Tallies
     void InitializeTallies( MonteCarlo *monteCarlo, 
                             int balance_replications, 
                             int flux_replications, 
-                            int cell_replications,
-                            std::string name,
-                            int numGroups);
+                            int cell_replications);
 
     void CycleInitialize(MonteCarlo* monteCarlo);
 

--- a/src/Tallies.hh
+++ b/src/Tallies.hh
@@ -11,8 +11,8 @@
 #include "utils.hh"
 #include "macros.hh"
 #include "BulkStorage.hh"
-
 #include "DeclareMacro.hh"
+#include "EnergySpectrum.hh"
 
 typedef unsigned long long int uint64_cu;
 
@@ -305,6 +305,7 @@ class Tallies
     qs_vector<ScalarFluxDomain> _scalarFluxDomain;
     qs_vector<CellTallyDomain>  _cellTallyDomain;
     Fluence                     _fluence;
+    EnergySpectrum              _spectrum;
     
     Tallies() : _balanceCumulative(), _balanceTask(),
         _scalarFluxDomain(), _num_balance_replications(1), 
@@ -340,7 +341,9 @@ class Tallies
     void InitializeTallies( MonteCarlo *monteCarlo, 
                             int balance_replications, 
                             int flux_replications, 
-                            int cell_replications);
+                            int cell_replications,
+                            std::string name,
+                            int numGroups);
 
     void CycleInitialize(MonteCarlo* monteCarlo);
 

--- a/src/initMC.cc
+++ b/src/initMC.cc
@@ -143,12 +143,14 @@ namespace
 
          monteCarlo->_nuclearData = new(ptr1) NuclearData(params.simulationParams.nGroups,
                                                           params.simulationParams.eMin,
-                                                          params.simulationParams.eMax);
+                                                          params.simulationParams.eMax,
+                                                          params.simulationParams.energySpectrum);
          monteCarlo->_materialDatabase = new(ptr2) MaterialDatabase();
      #else
          monteCarlo->_nuclearData = new NuclearData(params.simulationParams.nGroups,
                                                     params.simulationParams.eMin,
-                                                    params.simulationParams.eMax);
+                                                    params.simulationParams.eMax,
+                                                    params.simulationParams.energySpectrum);
          monteCarlo->_materialDatabase = new MaterialDatabase();
      #endif
 

--- a/src/initMC.cc
+++ b/src/initMC.cc
@@ -143,14 +143,12 @@ namespace
 
          monteCarlo->_nuclearData = new(ptr1) NuclearData(params.simulationParams.nGroups,
                                                           params.simulationParams.eMin,
-                                                          params.simulationParams.eMax,
-                                                          params.simulationParams.energySpectrum);
+                                                          params.simulationParams.eMax);
          monteCarlo->_materialDatabase = new(ptr2) MaterialDatabase();
      #else
          monteCarlo->_nuclearData = new NuclearData(params.simulationParams.nGroups,
                                                     params.simulationParams.eMin,
-                                                    params.simulationParams.eMax,
-                                                    params.simulationParams.energySpectrum);
+                                                    params.simulationParams.eMax);
          monteCarlo->_materialDatabase = new MaterialDatabase();
      #endif
 
@@ -337,7 +335,9 @@ namespace
          monteCarlo,  
          params.simulationParams.balanceTallyReplications,
          params.simulationParams.fluxTallyReplications,
-         params.simulationParams.cellTallyReplications
+         params.simulationParams.cellTallyReplications,
+         params.simulationParams.energySpectrum,
+         monteCarlo->_nuclearData->_numEnergyGroups
       );
    }
 }

--- a/src/initMC.cc
+++ b/src/initMC.cc
@@ -335,9 +335,7 @@ namespace
          monteCarlo,  
          params.simulationParams.balanceTallyReplications,
          params.simulationParams.fluxTallyReplications,
-         params.simulationParams.cellTallyReplications,
-         params.simulationParams.energySpectrum,
-         monteCarlo->_nuclearData->_numEnergyGroups
+         params.simulationParams.cellTallyReplications
       );
    }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -73,7 +73,6 @@ int main(int argc, char** argv)
    gameOver();
 
    coralBenchmarkCorrectness(mcco, params);
-   mcco->_nuclearData->_spectrum->PrintSpectrum(mcco);
 
 #ifdef HAVE_UVM
     mcco->~MonteCarlo();
@@ -93,6 +92,7 @@ void gameOver()
                                         mcco->processor_info-> num_processors,
                                         mcco->processor_info->comm_mc_world,
                                         mcco->_tallies->_balanceCumulative._numSegments);
+    mcco->_tallies->_spectrum.PrintSpectrum(mcco);
 }
 
 void cycleInit( bool loadBalance )
@@ -308,8 +308,6 @@ void cycleFinalize()
     MC_FASTTIMER_START(MC_Fast_Timer::cycleFinalize);
 
     mcco->_tallies->_balanceTask[0]._end = mcco->_particleVaultContainer->sizeProcessed();
-
-    mcco->_nuclearData->_spectrum->UpdateSpectrum(mcco);
 
     // Update the cumulative tally data.
     mcco->_tallies->CycleFinalize(mcco); 

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,6 +21,7 @@
 #include "qs_assert.hh"
 #include "CycleTracking.hh"
 #include "CoralBenchmark.hh"
+#include "EnergySpectrum.hh"
 
 #include "git_hash.hh"
 #include "git_vers.hh"
@@ -71,7 +72,8 @@ int main(int argc, char** argv)
 
    gameOver();
 
-    coralBenchmarkCorrectness(mcco, params);
+   coralBenchmarkCorrectness(mcco, params);
+   mcco->_nuclearData->_spectrum->PrintSpectrum(mcco);
 
 #ifdef HAVE_UVM
     mcco->~MonteCarlo();
@@ -99,7 +101,7 @@ void cycleInit( bool loadBalance )
     MC_FASTTIMER_START(MC_Fast_Timer::cycleInit);
 
     mcco->clearCrossSectionCache();
-       
+
     mcco->_tallies->CycleInitialize(mcco);
 
     mcco->_particleVaultContainer->swapProcessingProcessedVaults();
@@ -238,8 +240,7 @@ void cycleTracking(MonteCarlo *monteCarlo)
                 }
 
                 particle_count += numParticles;
-                
-                
+
                 // Next, communicate particles that have crossed onto
                 // other MPI ranks.
                 NVTX_Range cleanAndComm("cycleTracking_clean_and_comm");
@@ -307,6 +308,8 @@ void cycleFinalize()
     MC_FASTTIMER_START(MC_Fast_Timer::cycleFinalize);
 
     mcco->_tallies->_balanceTask[0]._end = mcco->_particleVaultContainer->sizeProcessed();
+
+    mcco->_nuclearData->_spectrum->UpdateSpectrum(mcco);
 
     // Update the cumulative tally data.
     mcco->_tallies->CycleFinalize(mcco); 


### PR DESCRIPTION
1) Added functions to compute the energy spectrum of particles that reach census
2) Added function to print hisogram of energy spectrum to a file
3) Made computing/printing energy spectrumn an input deck argument
   Turn on plotting energy spectrum by providing a file name in the input deck
   or command line