### PR TITLE
Memory Over Allocation Bug

### DIFF
--- a/src/GridAssignmentObject.cc
+++ b/src/GridAssignmentObject.cc
@@ -67,11 +67,6 @@ GridAssignmentObject::GridAssignmentObject(const vector<MC_Vector>& centers)
 
    _grid.resize( nCells );
 
-   for( int ii=0;ii<nCells;ii++)
-   {
-       _grid[ii]._myCenters.reserve(_centers.size());
-   }
-
    for (int ii=0; ii<_centers.size(); ++ii)
    {
       int iCell = whichCell(_centers[ii]);


### PR DESCRIPTION
Removed memory allocation hold over from qs_vector to std::vector change.

This asssumed worst case size and becomes a large over allocation for large problems.