### PR TITLE
Cycle Tracking Timers

### DIFF
--- a/src/MC_Fast_Timer.cc
+++ b/src/MC_Fast_Timer.cc
@@ -10,7 +10,8 @@ const char *mc_fast_timer_names[MC_Fast_Timer::Num_Timers] =
     "main",
     "cycleInit",
     "cycleTracking",
-    "cycleTracking_Segment",
+    "cycleTracking_Kernel",
+    "cycleTracking_MPI",
     "cycleTracking_Test_Done",
     "cycleFinalize"
 };
@@ -118,7 +119,10 @@ void MC_Fast_Timer_Container::Last_Cycle_Report(int mpi_rank, int num_ranks, MPI
     std::vector<uint64_t> std_dev_use(num_ranks);   // used to calculate standard deviation
 
     for ( int timer_index = 0; timer_index < MC_Fast_Timer::Num_Timers; timer_index++ )
-    { lastCycleClock[timer_index]  = this->timers[timer_index].lastCycleClock; }
+    {
+        lastCycleClock[timer_index]  = this->timers[timer_index].lastCycleClock;
+        this->timers[timer_index].lastCycleClock = 0;
+    }
 
     mpiReduce(&lastCycleClock[0], &max_clock[0], MC_Fast_Timer::Num_Timers, MPI_UINT64_T, MPI_MAX, 0, comm_world);
     mpiReduce(&lastCycleClock[0], &min_clock[0], MC_Fast_Timer::Num_Timers, MPI_UINT64_T, MPI_MIN, 0, comm_world);

--- a/src/MC_Fast_Timer.hh
+++ b/src/MC_Fast_Timer.hh
@@ -33,7 +33,8 @@ class MC_Fast_Timer
     main = 0,
     cycleInit,
     cycleTracking,
-    cycleTracking_Segment,
+    cycleTracking_Kernel,
+    cycleTracking_MPI,
     cycleTracking_Test_Done,
     cycleFinalize,
     Num_Timers
@@ -75,7 +76,7 @@ extern const char *mc_fast_timer_names[MC_Fast_Timer::Num_Timers];
       #define MC_FASTTIMER_STOP(timerIndex) \
           if ( omp_get_thread_num() == 0 ) { \
               mcco->fast_timer->timers[timerIndex].stopClock = mpiWtime(); \
-              mcco->fast_timer->timers[timerIndex].lastCycleClock   = \
+              mcco->fast_timer->timers[timerIndex].lastCycleClock   += \
 		(long unsigned) ((mcco->fast_timer->timers[timerIndex].stopClock - mcco->fast_timer->timers[timerIndex].startClock) * 1000000.0); \
               mcco->fast_timer->timers[timerIndex].cumulativeClock += \
 		(long unsigned) ((mcco->fast_timer->timers[timerIndex].stopClock - mcco->fast_timer->timers[timerIndex].startClock) * 1000000.0); \
@@ -94,7 +95,7 @@ extern const char *mc_fast_timer_names[MC_Fast_Timer::Num_Timers];
       #define MC_FASTTIMER_STOP(timerIndex) \
           if ( omp_get_thread_num() == 0 ) { \
               mcco->fast_timer->timers[timerIndex].stopClock = std::chrono::high_resolution_clock::now(); \
-              mcco->fast_timer->timers[timerIndex].lastCycleClock = \
+              mcco->fast_timer->timers[timerIndex].lastCycleClock += \
                 std::chrono::duration_cast<std::chrono::microseconds> \
 		(mcco->fast_timer->timers[timerIndex].stopClock - mcco->fast_timer->timers[timerIndex].startClock).count(); \
               mcco->fast_timer->timers[timerIndex].cumulativeClock += \

--- a/src/Makefile
+++ b/src/Makefile
@@ -171,24 +171,24 @@ LDFLAGS =
 ###############################################################################
 ## Choose one Cuda path
 ##CUDA_PATH = /usr/local/cuda-8.0
-CUDA_PATH = /usr/tcetmp/packages/cuda-9.0.176
+#CUDA_PATH = /usr/tcetmp/packages/cuda-9.0.176
 
-HOST_COMPILER = /usr/tce/packages/spectrum-mpi/spectrum-mpi-2017.04.03-xl-beta-2017.09.13/bin/mpixlC
+#HOST_COMPILER = /usr/tce/packages/spectrum-mpi/spectrum-mpi-2017.04.03-xl-beta-2017.09.13/bin/mpixlC
 
-OPTFLAGS = -O2 
-# Version below for debugging
-#OPTFLAGS = -DUSE_NVTX -g -G -lineinfo -O0
+#OPTFLAGS = -O2 
+## Version below for debugging
+##OPTFLAGS = -DUSE_NVTX -g -G -lineinfo -O0
 
-CUDA_FLAGS = -I${CUDA_PATH}/include/
-CUDA_LDFLAGS = -L${CUDA_PATH}/lib64/ -lcuda -lcudart
-
-CXX=$(CUDA_PATH)/bin/nvcc
-CXXFLAGS = -DHAVE_CUDA -std=c++11 $(OPTFLAGS) -Xptxas -v 
-CXXFLAGS += -gencode=arch=compute_60,code=\"sm_60,compute_60\" 
-CXXFLAGS += --compiler-bindir=$(HOST_COMPILER)
-CPPFLAGS = -x cu -dc -DHAVE_MPI -DHAVE_ASYNC_MPI
-LDFLAGS  = $(CUDA_LDFLAGS) 
-#LDFLAGS += ${CUDA_PATH}/lib64/libnvToolsExt.so
+#CUDA_FLAGS = -I${CUDA_PATH}/include/
+#CUDA_LDFLAGS = -L${CUDA_PATH}/lib64/ -lcuda -lcudart
+#
+#CXX=$(CUDA_PATH)/bin/nvcc
+#CXXFLAGS = -DHAVE_CUDA -std=c++11 $(OPTFLAGS) -Xptxas -v 
+#CXXFLAGS += -gencode=arch=compute_60,code=\"sm_60,compute_60\" 
+#CXXFLAGS += --compiler-bindir=$(HOST_COMPILER)
+#CPPFLAGS = -x cu -dc -DHAVE_MPI -DHAVE_ASYNC_MPI
+#LDFLAGS  = $(CUDA_LDFLAGS) 
+##LDFLAGS += ${CUDA_PATH}/lib64/libnvToolsExt.so
 
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -171,24 +171,24 @@ LDFLAGS =
 ###############################################################################
 ## Choose one Cuda path
 ##CUDA_PATH = /usr/local/cuda-8.0
-#CUDA_PATH = /usr/tcetmp/packages/cuda-9.0.176
+CUDA_PATH = /usr/tcetmp/packages/cuda-9.0.176
 
-#HOST_COMPILER = /usr/tce/packages/spectrum-mpi/spectrum-mpi-2017.04.03-xl-beta-2017.09.13/bin/mpixlC
+HOST_COMPILER = /usr/tce/packages/spectrum-mpi/spectrum-mpi-2017.04.03-xl-beta-2017.09.13/bin/mpixlC
 
-#OPTFLAGS = -O2 
-## Version below for debugging
-##OPTFLAGS = -DUSE_NVTX -g -G -lineinfo -O0
+OPTFLAGS = -O2 
+# Version below for debugging
+#OPTFLAGS = -DUSE_NVTX -g -G -lineinfo -O0
 
-#CUDA_FLAGS = -I${CUDA_PATH}/include/
-#CUDA_LDFLAGS = -L${CUDA_PATH}/lib64/ -lcuda -lcudart
-#
-#CXX=$(CUDA_PATH)/bin/nvcc
-#CXXFLAGS = -DHAVE_CUDA -std=c++11 $(OPTFLAGS) -Xptxas -v 
-#CXXFLAGS += -gencode=arch=compute_60,code=\"sm_60,compute_60\" 
-#CXXFLAGS += --compiler-bindir=$(HOST_COMPILER)
-#CPPFLAGS = -x cu -dc -DHAVE_MPI -DHAVE_ASYNC_MPI
-#LDFLAGS  = $(CUDA_LDFLAGS) 
-##LDFLAGS += ${CUDA_PATH}/lib64/libnvToolsExt.so
+CUDA_FLAGS = -I${CUDA_PATH}/include/
+CUDA_LDFLAGS = -L${CUDA_PATH}/lib64/ -lcuda -lcudart
+
+CXX=$(CUDA_PATH)/bin/nvcc
+CXXFLAGS = -DHAVE_CUDA -std=c++11 $(OPTFLAGS) -Xptxas -v 
+CXXFLAGS += -gencode=arch=compute_60,code=\"sm_60,compute_60\" 
+CXXFLAGS += --compiler-bindir=$(HOST_COMPILER)
+CPPFLAGS = -x cu -dc -DHAVE_MPI -DHAVE_ASYNC_MPI
+LDFLAGS  = $(CUDA_LDFLAGS) 
+#LDFLAGS += ${CUDA_PATH}/lib64/libnvToolsExt.so
 
 
 


### PR DESCRIPTION
Added meaningful timers to cycle tracking to distinguish between the kernel and MPI. Fixed last cycle timer logic to be an accumulation of each timer call for each cycle when used.