### PR TITLE
Remove nBatches and batchSize parameters from Coral2 sample inputs.

### DIFF
--- a/Examples/CORAL2_Benchmark/Problem1/Coral2_P1.inp
+++ b/Examples/CORAL2_Benchmark/Problem1/Coral2_P1.inp
@@ -6,7 +6,6 @@ Simulation:
    cycleTimers: 0
    debugThreads: 0
    mpiThreadMultiple: 0
-   nBatches: 10
    nSteps: 100 
    seed: 1029384756
    eMax: 20

--- a/Examples/CORAL2_Benchmark/Problem1/Coral2_P1_1.inp
+++ b/Examples/CORAL2_Benchmark/Problem1/Coral2_P1_1.inp
@@ -10,7 +10,6 @@ Simulation:
    ly: 16
    lz: 16
    nParticles: 163840
-   nBatches: 10
    nSteps: 100 
    nx: 16
    ny: 16

--- a/Examples/CORAL2_Benchmark/Problem1/Coral2_P1_4096.inp
+++ b/Examples/CORAL2_Benchmark/Problem1/Coral2_P1_4096.inp
@@ -10,7 +10,6 @@ Simulation:
    ly: 256
    lz: 256
    nParticles: 671088640
-   nBatches: 10
    nSteps: 100 
    nx: 256
    ny: 256

--- a/Examples/CORAL2_Benchmark/Problem2/Coral2_P2.inp
+++ b/Examples/CORAL2_Benchmark/Problem2/Coral2_P2.inp
@@ -5,8 +5,6 @@ Simulation:
    loadBalance: 0
    cycleTimers: 0
    debugThreads: 0
-   batchSize: 0
-   nBatches: 10
    nSteps: 100
    seed: 1029384756
    eMax: 20

--- a/Examples/CORAL2_Benchmark/Problem2/Coral2_P2_1.inp
+++ b/Examples/CORAL2_Benchmark/Problem2/Coral2_P2_1.inp
@@ -9,8 +9,6 @@ Simulation:
    ly: 1
    lz: 1
    nParticles: 53240
-   batchSize: 0
-   nBatches: 10
    nSteps: 100
    nx: 11
    ny: 11

--- a/Examples/CORAL2_Benchmark/Problem2/Coral2_P2_4096.inp
+++ b/Examples/CORAL2_Benchmark/Problem2/Coral2_P2_4096.inp
@@ -9,8 +9,6 @@ Simulation:
    ly: 16
    lz: 16
    nParticles: 436142080
-   batchSize: 0
-   nBatches: 10
    nSteps: 100
    nx: 176
    ny: 176


### PR DESCRIPTION
This allows these parameters to be set on the command line.