### PR TITLE
Fixing Last Cycle Timers:

### DIFF
--- a/src/MC_Fast_Timer.hh
+++ b/src/MC_Fast_Timer.hh
@@ -46,7 +46,8 @@ class MC_Fast_Timer_Container
 public:
     MC_Fast_Timer_Container() {} ; // constructor
     void Cumulative_Report(int mpi_rank, int num_ranks, MPI_Comm comm_world, uint64_t numSegments);
-    void Last_Cycle_Report(int mpi_rank, int num_ranks, MPI_Comm comm_world);
+    void Last_Cycle_Report(int report_time, int mpi_rank, int num_ranks, MPI_Comm comm_world);
+    void Clear_Last_Cycle_Timers();
     MC_Fast_Timer  timers[MC_Fast_Timer::Num_Timers];  // timers for various routines
 
 private:

--- a/src/main.cc
+++ b/src/main.cc
@@ -58,13 +58,11 @@ int main(int argc, char** argv)
       cycleTracking(mcco);
       cycleFinalize();
 
-      if (params.simulationParams.cycleTimers == 1)
-      {
-         mcco->fast_timer->Last_Cycle_Report(
+      mcco->fast_timer->Last_Cycle_Report(
+            params.simulationParams.cycleTimers,
             mcco->processor_info->rank,
             mcco->processor_info->num_processors,
             mcco->processor_info->comm_mc_world );
-      }
    }
 
 


### PR DESCRIPTION
Last Cycle timers where only being cleared if the print last cycle timers paramter was set.
Fixed this by making sure last cycle timers are cleared at the end of each cycle regardless
of if we want more verbose timer printing.