### PR TITLE
Fix two minor memory leaks.

### DIFF
--- a/src/BulkStorage.hh
+++ b/src/BulkStorage.hh
@@ -26,17 +26,16 @@ class BulkStorage
    
    ~BulkStorage()
    {
-      // Check for instances that never allocated memory.
-      // I'm not exactly sure how this can happen, but it does.
-      if (_bulkStorage == 0) 
-         return;
-      
       --(*_refCount);
       if (*_refCount > 0)
          return;
-            
-      MemoryControl::deallocate(_bulkStorage, _capacity, _memPolicy);
+
       delete _refCount;
+
+      // Catch the case that the storage was never allocated.  This
+      // happens when setCapacity is never called on this instance.
+      if (_bulkStorage != 0) 
+         MemoryControl::deallocate(_bulkStorage, _capacity, _memPolicy);
    }
    
    /// Needed for copy-swap idiom

--- a/src/MC_Processor_Info.hh
+++ b/src/MC_Processor_Info.hh
@@ -2,7 +2,6 @@
 #define MC_PROCESSOR_INFO_HH
 
 #include "utilsMpi.hh"
-#include "macros.hh"
 
 class MC_Processor_Info
 {
@@ -10,32 +9,20 @@ public:
 
     int rank;
     int num_processors;
-    int num_tasks;
     int use_gpu;
     int gpu_id;
 
     MPI_Comm  comm_mc_world;
-    MPI_Comm *comm_mc_world_threads;  // Communicator to allow threads to make MPI calls.
 
-    MC_Processor_Info() : comm_mc_world(MPI_COMM_WORLD)
+    MC_Processor_Info()
+    : comm_mc_world(MPI_COMM_WORLD),
+      use_gpu(0),
+      gpu_id(0)
     {
       mpiComm_rank(comm_mc_world, &rank);
       mpiComm_size(comm_mc_world, &num_processors);
-//      num_tasks = omp_get_max_threads();
-      num_tasks = 1;
-      comm_mc_world_threads = new MPI_Comm[num_tasks];
-
-      for (int thread_ndx=0; thread_ndx<num_tasks; ++thread_ndx)
-      {
-         mpiComm_split(comm_mc_world, thread_ndx, 0, &comm_mc_world_threads[thread_ndx]);
-      }
-
-      use_gpu = 0;
-      gpu_id = 0;
     }
 
 };
-
-
 
 #endif


### PR DESCRIPTION
Fix two minor memory leaks.  Neither of these are likely to ever cause
a problem, but the clang leak sanitizer now reports no errors (at least
not for the default problem).