### PR TITLE
match HOST_DEVICE_CUDA on decl and def

### DIFF
--- a/src/MC_Particle.hh
+++ b/src/MC_Particle.hh
@@ -127,6 +127,7 @@ public:
 //----------------------------------------------------------------------------------------------------------------------
 //  Return a MC_Location given domain, cell, facet.
 //----------------------------------------------------------------------------------------------------------------------
+   HOST_DEVICE_CUDA
 inline MC_Location MC_Particle::Get_Location() const
 {
     return MC_Location(domain, cell, facet);
@@ -135,6 +136,7 @@ inline MC_Location MC_Particle::Get_Location() const
 //----------------------------------------------------------------------------------------------------------------------
 //  Move the particle a straight-line distance along a specified cosine.
 //----------------------------------------------------------------------------------------------------------------------
+   HOST_DEVICE_CUDA
 inline void MC_Particle::Move_Particle( const DirectionCosine &my_direction_cosine,
                                       const double distance)
 {

--- a/src/ParticleVault.hh
+++ b/src/ParticleVault.hh
@@ -171,6 +171,7 @@ getParticle( MC_Particle &particle, int index )
 }
 
 // -----------------------------------------------------------------------
+   HOST_DEVICE_CUDA
 inline bool ParticleVault::
 putParticle(MC_Particle particle, int index)
 {
@@ -185,6 +186,7 @@ putParticle(MC_Particle particle, int index)
 }
 
 // -----------------------------------------------------------------------
+   HOST_DEVICE_CUDA
 inline void ParticleVault::
 invalidateParticle( int index )
 {


### PR DESCRIPTION
Fixes errors like this:
```
~/QUICKSILVER/src/MC_Particle.hh:130:33: error: __host__ function 'Get_Location' cannot overload __host__ __device__ function 'Get_Location'
inline MC_Location MC_Particle::Get_Location() const
                                ^
~/QUICKSILVER/src/MC_Particle.hh:102:16: note: previous declaration is here
   MC_Location Get_Location() const;
```
Signed-off-by: Jeff Hammond <jeff.r.hammond@intel.com>