### PR TITLE
hipFree --> free

### DIFF
--- a/src/MonteCarlo.cc
+++ b/src/MonteCarlo.cc
@@ -141,9 +141,9 @@ MonteCarlo::~MonteCarlo()
         fast_timer->~MC_Fast_Timer_Container();
         particle_buffer->~MC_Particle_Buffer();
 
-        hipFree( _nuclearData );
+        free( _nuclearData );
         gpuFree( _particleVaultContainer);
-        hipFree( _materialDatabase);
+        free( _materialDatabase);
         gpuFree( _tallies);
         gpuFree( processor_info);
         gpuFree( time_info);


### PR DESCRIPTION
This PR fixes a segfault.  When `HAVE_UVM=1` ,  `_nuclearData` and `materialDatabase` point to memory allocated with `calloc` (see [initMC.cc](https://github.com/LLNL/Quicksilver/blob/AMD-HIP/src/initMC.cc#L163-L170) ).