### PR TITLE
Synch before device-to-host copy

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -296,9 +296,9 @@ void cycleTracking(MonteCarlo *monteCarlo, uint64_cu* tallies, uint64_cu * talli
                                    std::cout << "error: #" << errorchk << " (" << hipGetErrorString(errorchk) << std::endl;
                                    abort();
                               }
-
-                              //Synchronize the stream
+                              
                           }
+                          hipDeviceSynchronize();
                           hipMemcpy(tallies,tallies_d,NUM_TALLIES*sizeof(uint64_cu)*replications,hipMemcpyDeviceToHost);
 
                           #endif


### PR DESCRIPTION
This PR adds a synch after `CycleTrackingKernel` but before `hipMemCpy` of `values_d` to `values`, so that `values_d` is fully updated before the copy.  Without this synch, later iterations of `CycleTrackingKernel` can get an `HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION`, to be understood as GPU memory bus error.  The backtrace (for a single-rank, single GPU case run as `./qs -i ../Examples/CORAL2_Benchmark/Problem1/Coral2_P1.inp -X 32 -Y 32 -Z 16 -x 32 -y 32 -z 16 -I 1 -J 1 -K 1 -b 12 -n 4000000`):
```
0x00007ffe8045b698 in MC_Vector::operator= (this=<optimized out>, tmp=...) at ./MC_Vector.hh:26
26	      y = tmp.y;
(gdb) bt
#0  0x00007ffe8045b698 in MC_Vector::operator= (this=<optimized out>, tmp=...) at ./MC_Vector.hh:26
#1  0x00007ffe8046a4ac in MC_Base_Particle::operator= (this=<optimized out>) at ./MC_Base_Particle.hh:26
#2  0x00007ffe8046a9ac in ParticleVault::pushParticle (this=<optimized out>, particle=...) at ./ParticleVault.hh:98
#3  0x00007ffe804730b4 in CycleTrackingFunction (monteCarlo=<optimized out>, mc_particle=..., particle_index=<optimized out>, processingVault=<optimized out>, 
    processedVault=<optimized out>, vaultIndex=<optimized out>) at ./CycleTracking.hh:120
#4  0x00007ffe80473bbc in CycleTrackingGuts (monteCarlo=<optimized out>, particle_index=<optimized out>, processingVault=<optimized out>, processedVault=<optimized out>, 
    vaultIndex=<optimized out>) at ./CycleTracking.hh:164
#5  0x00007ffe80458444 in CycleTrackingKernel (monteCarlo=<optimized out>, num_particles=<optimized out>, processingVault=<optimized out>, processedVault=<optimized out>, 
    values=<optimized out>) at main.cc:199
```   
shows that a segfault can eventually appear when copying `MC_Base_Particle`s in the `CycleTrackingKernel`.  
(backtrace was collected with a similar branch, the lines do not correspond precisely to this branch.)

I also removed an extraneous comment about stream synchronization because all kernels are evidently launched on the default stream.