### PR TITLE
Fix examples

### DIFF
--- a/Examples/AllEscape/allEscape.inp
+++ b/Examples/AllEscape/allEscape.inp
@@ -1,5 +1,6 @@
 Simulation:
    dt: 1e6
+   boundaryCondition: escape
    fMax: 0.1
    inputFile: 
    loadBalance: 1

--- a/src/NuclearData.cc
+++ b/src/NuclearData.cc
@@ -28,7 +28,7 @@ NuclearDataReaction::NuclearDataReaction(
    // value of the energy group that contains 1 MeV
    double normalization = 0.0;
    for (unsigned ii=0; ii<nGroups; ++ii)
-      if (energies[ii+1] > 1. ) //1 MeV
+      if (energies[ii+1] >= 1. ) //1 MeV
       {
          normalization = _crossSection[ii];
          break;


### PR DESCRIPTION
Some examples (allAbsorb and allEscape) did not work as expected.

allAbsorb generates assert errors and then segfault, and allEscape was not terminating.

These two small changes seem to fix this.