### PR TITLE
Updated CUDA and MPI Versions in Makefile for LLNL CUDA CORAL EA Example

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -171,9 +171,9 @@ LDFLAGS =
 ###############################################################################
 ## Choose one Cuda path
 ##CUDA_PATH = /usr/local/cuda-8.0
-#CUDA_PATH = /usr/tcetmp/packages/cuda-9.0.176
+#CUDA_PATH =/usr/tce/packages/cuda/cuda-12.0.0
 
-#HOST_COMPILER = /usr/tce/packages/spectrum-mpi/spectrum-mpi-2017.04.03-xl-beta-2017.09.13/bin/mpixlC
+#HOST_COMPILER =/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-2022.08.19/bin/mpixlC
 
 #OPTFLAGS = -O2 
 ## Version below for debugging


### PR DESCRIPTION
The old version of MPI casued compilation issues on LLNL's CORAL EA systems. To address this, I've upgraded both the CUDA and MPI versions to a much newer releases. After making these changes, I tested the code on the Lassen cluster to confirm its functionality and compatibility. These updates should ensure better performance and robustness on CORAL EA systems.